### PR TITLE
feat: ✨ add multi-domain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /dist
 *.ini
+__pycache__

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Run
 ## Configuration
 Several configuration variables are available on the AWS-Certbot lambda function:
 
-`CERTBOT_BUCKET` - bucket name containing AWS-Certbot code
+`CERTBOT_BUCKET` - Bucket name containing AWS-Certbot code
 
-`DOMAIN_EMAIL` - email address to use for [letsencrypt.org](https://letsencrypt.org) registration
+`DOMAIN_EMAIL` - Email address to use for [letsencrypt.org](https://letsencrypt.org) registration
 
-`DOMAIN_LIST` - comma separated list of domains/subdomains to enlist for automatic renewal (eg. `foo.com,subdomain.foo.com`).  Multiple domains are separated by semi-colons (eg. `foo.com,subdomain.foo.com;bar.com,*.bar.com`)
+`DOMAIN_LIST` - Comma separated list of domains/subdomains to enlist for automatic renewal (eg. `foo.com,subdomain.foo.com`).  Multiple domains are separated by semi-colons (eg. `foo.com,subdomain.foo.com;bar.com,*.bar.com`)
 
-`CERTS_RENEW_DAYS_BEFORE_EXPIRATION` - number of days before expiration to attempt renewal
+`CERTS_RENEW_DAYS_BEFORE_EXPIRATION` - Number of days before expiration to attempt renewal
 
 ## Credits
 AWS-Certbot is based largely on the following amazing projects:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Several configuration variables are available on the AWS-Certbot lambda function
 
 `DOMAIN_EMAIL` - email address to use for [letsencrypt.org](https://letsencrypt.org) registration
 
-`DOMAIN_LIST` - comma separated list of domains/subdomains to enlist for automatic renewal (eg. `letsencrypt.org,subdomain.letsencrypt.org`)
+`DOMAIN_LIST` - comma separated list of domains/subdomains to enlist for automatic renewal (eg. `foo.com,subdomain.foo.com`).  Multiple domains are separated by semi-colons (eg. `foo.com,subdomain.foo.com;bar.com,*.bar.com`)
 
 `CERTS_RENEW_DAYS_BEFORE_EXPIRATION` - number of days before expiration to attempt renewal
 

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -30,7 +30,7 @@ function Main {
   $GUID = New-Guid
   Clean
   Build($GUID)
-  # Deploy($GUID)
+  Deploy($GUID)
 }
 
 Main

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -6,7 +6,7 @@ function Clean {
 function Build($ID) {
   Get-ChildItem .\certbot*.zip -File | Select-Object -First 1 | Expand-Archive -DestinationPath .\build -Force
   New-Item -Path . -Name "dist" -ItemType "directory" -Force
-  Compress-Archive -Path .\build\*,.\*.py,.\*.ini -DestinationPath .\dist\certbot-${ID}.zip -Force
+  Compress-Archive -Path .\build\*,.\src\*,.\*.ini -DestinationPath .\dist\certbot-${ID}.zip -Force
 }
 
 function CreateBucket($Bucket) {
@@ -30,7 +30,7 @@ function Main {
   $GUID = New-Guid
   Clean
   Build($GUID)
-  Deploy($GUID)
+  # Deploy($GUID)
 }
 
 Main

--- a/domain.py
+++ b/domain.py
@@ -1,0 +1,3 @@
+class Domain:
+    def __init__(self, domains):
+        self.original = domains

--- a/domain.py
+++ b/domain.py
@@ -1,3 +1,0 @@
-class Domain:
-    def __init__(self, domains):
-        self.original = domains

--- a/main.py
+++ b/main.py
@@ -12,6 +12,18 @@ logger.setLevel(logging.INFO)
 s3 = boto3.client('s3')
 acm = boto3.client('acm')
 
+def is_wildcard_domain(domain):
+    wildcard_marker: Union[Text, bytes] = b"*."
+    if isinstance(domain, str):
+        wildcard_marker = u"*."
+    return domain.startswith(wildcard_marker)
+
+def choose_lineagename(domains):
+    if is_wildcard_domain(domains[0]):
+        # Don't make files and directories starting with *.
+        return domains[0][2:]
+    return domains[0]
+
 def get_challenge():
     if (os.path.isfile('./cloudflare.ini')):
         logger.info('Cloudflare configuration detected')

--- a/src/aws_certbot/domain_list.py
+++ b/src/aws_certbot/domain_list.py
@@ -1,0 +1,27 @@
+class DomainList:
+    def __init__(self, domains):
+        self.original = domains
+        self.lineage = self.parse(domains)
+
+    def parse(self, domains):
+        groups = domains.split(';')
+        result = {}
+        for doms in groups:
+            items = doms.split(',')
+            lineage = self.choose_lineagename(items[0].strip())
+            result[lineage] = ','.join(i.strip() for i in items)
+        return result
+
+    def is_wildcard_domain(self, domain):
+        wildcard_marker: Union[Text, bytes] = b"*."
+        if isinstance(domain, str):
+            wildcard_marker = u"*."
+        return domain.startswith(wildcard_marker)
+
+    def choose_lineagename(self, domain):
+        if self.is_wildcard_domain(domain):
+            return domain[2:]
+        return domain
+
+    def to_string(self):
+        return '({0})'.format(self.original)

--- a/src/main.py
+++ b/src/main.py
@@ -12,18 +12,6 @@ logger.setLevel(logging.INFO)
 s3 = boto3.client('s3')
 acm = boto3.client('acm')
 
-def is_wildcard_domain(domain):
-    wildcard_marker: Union[Text, bytes] = b"*."
-    if isinstance(domain, str):
-        wildcard_marker = u"*."
-    return domain.startswith(wildcard_marker)
-
-def choose_lineagename(domains):
-    if is_wildcard_domain(domains[0]):
-        # Don't make files and directories starting with *.
-        return domains[0][2:]
-    return domains[0]
-
 def get_challenge():
     if (os.path.isfile('./cloudflare.ini')):
         logger.info('Cloudflare configuration detected')

--- a/src/test/test_domain_list.py
+++ b/src/test/test_domain_list.py
@@ -1,0 +1,87 @@
+import unittest
+from aws_certbot.domain_list import DomainList
+
+class TestDomainList(unittest.TestCase):
+
+    def test_initializer(self):
+        domains = 'example.com,*.example.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.original, domains)
+
+    def test_parse(self):
+        domains = 'example.com,*.example.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'example.com': 'example.com,*.example.com'
+        })
+
+    def test_parse_reverse(self):
+        domains = '*.example.com,example.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'example.com': '*.example.com,example.com'
+        })
+
+    def test_parse_wildcard(self):
+        domains = '*.example.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'example.com': '*.example.com'
+        })
+
+    def test_parse_determanistic1(self):
+        domains = 'aa.example.com,aab.example.com,bcd.example.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'aa.example.com': 'aa.example.com,aab.example.com,bcd.example.com'
+        })
+
+    def test_parse_determanistic2(self):
+        domains = 'aab.example.com,aa.example.com,bcd.example.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'aab.example.com': 'aab.example.com,aa.example.com,bcd.example.com'
+        })
+
+    def test_parse_group(self):
+        domains = 'foo.com,*.foo.com;bar.com,*.bar.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'foo.com': 'foo.com,*.foo.com',
+            'bar.com': 'bar.com,*.bar.com'
+        })
+
+    def test_parse_reverse_group(self):
+        domains = '*.foo.com,foo.com;*.bar.com,bar.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'foo.com': '*.foo.com,foo.com',
+            'bar.com': '*.bar.com,bar.com'
+        })
+
+    def test_parse_wildcard_group(self):
+        domains = '*.foo.com;*.bar.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'foo.com': '*.foo.com',
+            'bar.com': '*.bar.com'
+        })
+
+    def test_parse_determanistic1_group(self):
+        domains = 'aa.foo.com,aab.foo.com,bcd.foo.com;aa.bar.com,aab.bar.com,bcd.bar.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'aa.foo.com': 'aa.foo.com,aab.foo.com,bcd.foo.com',
+            'aa.bar.com': 'aa.bar.com,aab.bar.com,bcd.bar.com'
+        })
+
+    def test_parse_determanistic2_group(self):
+        domains = 'aab.foo.com,aa.foo.com,bcd.foo.com;aab.bar.com,aa.bar.com,bcd.bar.com'
+        dlist = DomainList(domains)
+        self.assertEqual(dlist.lineage, {
+            'aab.foo.com': 'aab.foo.com,aa.foo.com,bcd.foo.com',
+            'aab.bar.com': 'aab.bar.com,aa.bar.com,bcd.bar.com'
+        })
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Multiple domains can be added for processing via the `DOMAIN_LIST` 
config.  Domains are separated by commas while domain groups are 
separated by semi-colons (eg.`foo.com,sub.foo.com;bar.com,*.bar.com`)

Closes #6