### PR TITLE
fix: ⚡️ remove cloudflare processing delay

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,6 @@ def get_challenge():
         logger.info('Cloudflare configuration detected')
         return [
             '--dns-cloudflare',
-            '--dns-cloudflare-propagation-seconds', '60',
             '--dns-cloudflare-credentials', './cloudflare.ini'
         ]
     else:


### PR DESCRIPTION
Remove `dns-cloudflare-propagation-seconds=60` param since the default
10s delay seems sufficient

Closes #17