### PR TITLE
feat: add lambda timeout

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,3 +24,6 @@ DOMAIN_EMAIL=user@example.com
 
 # <REQUIRED> Number of days before expiration to request renewal
 DAYS_BEFORE_EXPIRATION=20
+
+# <REQUIRED> Lambda timeout in seconds
+LAMBDA_TIMEOUT=300

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Running **aws-certbot** locally will:
 | DOMAIN_LIST | A list of domains separated by commas and semicolons. The semicolon separates groups of domains, while commas separate individual domains. For example: `domain.com,*.domain.com;example.io,staging.example.io` |  ✅ |
 | DOMAIN_EMAIL | Cloudflare API key with edit.zone permissions |  ✅ |
 | DAYS_BEFORE_EXPIRATION | Number of days before expiration to request renewal |  ✅ |
+| LAMBDA_TIMEOUT | Lambda timeout in seconds |  ✅ |
 
 ## Deploying to AWS
 

--- a/cloud.yaml
+++ b/cloud.yaml
@@ -18,6 +18,9 @@ Parameters:
   DaysBeforeExpiration:
     Type: String
 
+  LambdaTimeout:
+    Type: String
+
   Timestamp:
     Type: String
 
@@ -69,7 +72,7 @@ Resources:
           DOMAIN_EMAIL: !Ref DomainEmail
           DOMAIN_LIST: !Ref DomainList
           DAYS_BEFORE_EXPIRATION: !Ref DaysBeforeExpiration
-      Timeout: 120
+      Timeout: !Ref LambdaTimeout
       MemorySize: 512
       Code:
         ImageUri: !Sub "${EcrRepositoryUri}:latest"

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,6 +40,7 @@ aws cloudformation deploy --stack-name ${APP_NAME} \
     DomainList=${DOMAIN_LIST} \
     DomainEmail=${DOMAIN_EMAIL} \
     DaysBeforeExpiration=${DAYS_BEFORE_EXPIRATION} \
+    LambdaTimeout=${LAMBDA_TIMEOUT} \
     Timestamp=${TIMESTAMP} \
   --capabilities CAPABILITY_IAM
 


### PR DESCRIPTION
Add a lambda timeout parameter; it takes 1 minute for each domain lineage to be processed. `LAMBDA_TIMEOUT` should be set to a number greater than what is needed.

closes #32